### PR TITLE
Stream output JSON directly to stdout

### DIFF
--- a/nrbf.py
+++ b/nrbf.py
@@ -726,9 +726,9 @@ def multidimensional_array(lengths):
 if __name__ == '__main__':
     if len(sys.argv) != 2:
         sys.exit(f'Usage: {sys.argv[0]} streamfile')
-    json_encoder = JSONEncoder(indent=4)
     with open(sys.argv[1], 'rb') as streamfile:
         while True:
-            print(json_encoder.encode(read_stream(streamfile)))
+            json.dump(read_stream(streamfile), sys.stdout, cls=JSONEncoder, indent=4)
+            print()
             if streamfile.peek(1) == b'':
                 break


### PR DESCRIPTION
This improves performance tremendously. For a 1.7MiB .NET object dump peak memory usage goes from ~840MiB to ~17MiB, the resulting JSON is dumped faster too as there's no need to wait until the whole string is allocated.